### PR TITLE
fix two typos caught by lintian

### DIFF
--- a/parsnp
+++ b/parsnp
@@ -411,7 +411,7 @@ def parse_args():
         "-u",
         "--unaligned",
         action = "store_true",
-        help = "Ouput unaligned regions")
+        help = "Output unaligned regions")
 
     recombination_args = parser.add_argument_group("Recombination filtration")
     #TODO -x was a duplicate flag but no longer parsed as filter-phipack-snps in the current parsnp version

--- a/src/parsnp.cpp
+++ b/src/parsnp.cpp
@@ -3253,7 +3253,7 @@ int main ( int argc, char* argv[] )
     dif = difftime (tend,tstart);
     
     cerr << "Parsnp: Finished core genome alignment" << endl;
-    printf("        See log file for futher details. Total processing time: %.0lf seconds \n\n", dif );
+    printf("        See log file for further details. Total processing time: %.0lf seconds \n\n", dif );
     exit(0);
 }
 


### PR DESCRIPTION
Good day,

While working on upgrading the _parsnp_ package for debian sid, our linter caught two typos which you might want to see fixed in the next releases.

Have a nice day,  :)
Étienne.