### PR TITLE
fix the off-by-one problem with first contig

### DIFF
--- a/src/parsnp.cpp
+++ b/src/parsnp.cpp
@@ -1000,19 +1000,19 @@ void Aligner::writeOutput(string psnp,vector<float>& coveragerow)
                     } // Cannot have empty header very hard to parse
                     if ( !ct.mums.at(0).isforward.at(i) )
                     {
-                        xmfafile << "- cluster" << b << " " << hdr1 << ":p" << (ct.start.at(i) - seqstart) + 1 + ct.mums.at(0).length << endl;
+                        xmfafile << "- cluster" << b << " " << hdr1 << ":p" << (ct.start.at(i) - seqstart) + ((hdr1 == "s1") ? 2 : 1) + ct.mums.at(0).length << endl;
                         if(recomb_filter)
                         {
-                            
-                            clcbfile << "- cluster" << b << " "  << hdr1 << ":p" << (ct.start.at(i)-seqstart)+ 1 + ct.mums.at(0).length << endl;
+
+                            clcbfile << "- cluster" << b << " " << hdr1 << ":p" << (ct.start.at(i) - seqstart) + ((hdr1 == "s1") ? 2 : 1) + ct.mums.at(0).length << endl;
                         }
                     } // Tenery added for single contigs
                     else
                     {
-                        xmfafile << "+ cluster" << b << " "  << hdr1 << ":p" << (ct.start.at(i)-seqstart)+ 1 << endl;
+                        xmfafile << "+ cluster" << b << " " << hdr1 << ":p" << (ct.start.at(i) - seqstart) + ((hdr1 == "s1") ? 2 : 1) << endl;
                         if(recomb_filter)
                         {
-                            clcbfile << "+ cluster" << b << " "  << hdr1 << ":p" << (ct.start.at(i)-seqstart)+ 1 << endl;
+                            clcbfile << "+ cluster" << b << " " << hdr1 << ":p" << (ct.start.at(i) - seqstart) + ((hdr1 == "s1") ? 2 : 1) << endl;
                         }
                     }
                     for( k = 0; k+width < s1s.size();)


### PR DESCRIPTION
Fixed off-by-one problem with first contig. Now both Parsnp output and validation script are 1-indexed. 