### PR TITLE
Fix phipack

### DIFF
--- a/parsnp
+++ b/parsnp
@@ -1774,9 +1774,9 @@ SETTINGS:
     # Harvest seems to fail sometimes when piping to stderr/stdout...
     run_command(command)
 
-    if run_recomb_filter and not args.partition:
+    if run_recomb_filter:
         command = "harvesttools -q -b %s/parsnp.rec,REC,\"PhiPack\" -o %s/parsnp.ggr -i %s/parsnp.ggr"%(outputDir,outputDir,outputDir)
-        run_logged_command(command, outputDir, label="recomb-filter")
+        run_command(command)
 
     run_logged_command(
         f"harvesttools -i {outputDir}/parsnp.ggr -S {outputDir}/parsnp.snps.mblocks",

--- a/parsnp
+++ b/parsnp
@@ -25,7 +25,7 @@ from pathlib import Path
 import extend as ext
 from tqdm import tqdm
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 reroot_tree = True #use --midpoint-reroot
 random_seeded = random.Random(42)
 

--- a/parsnp
+++ b/parsnp
@@ -144,13 +144,13 @@ signal.signal(signal.SIGINT, handler)
 def xmfa_to_maf(xmfa_path, maf_path, all_input_paths):
     sample_delim = '#'
     SeqInfo = namedtuple("SeqInfo", "cid seq_length")
-    hdr_block_pattern = re.compile("##SequenceIndex (\d+)\n##SequenceFile (.+)\n##SequenceHeader >\s*(\S+).*\n##SequenceLength (\d+)bp")
+    hdr_block_pattern = re.compile(r"##SequenceIndex (\d+)\n##SequenceFile (.+)\n##SequenceHeader >\s*(\S+).*\n##SequenceLength (\d+)bp")
     idx_to_fname = {}
     ref_fname = ""
     with open(xmfa_path) as xmfa_in:
         next(xmfa_in) # skip version
         line = next(xmfa_in)
-        seq_count = int(re.match("#SequenceCount (\d+)\n", line).groups()[0])
+        seq_count = int(re.match(r"#SequenceCount (\d+)\n", line).groups()[0])
         for i in range(seq_count):
             info_block = ""
             for _ in range(4):


### PR DESCRIPTION
* Removes log redirects for harvest which cause crashes
* Uses regex strings for the parsers #153 
* Adds back the gingr support for phipack results