### PR TITLE
Issue 156

### DIFF
--- a/parsnp
+++ b/parsnp
@@ -22,7 +22,6 @@ from glob import glob
 from pathlib import Path
 
 
-import extend as ext
 from tqdm import tqdm
 
 __version__ = "2.0.5"


### PR DESCRIPTION
Previously we were importing the extension module even if the user didn't need it. This required the pyspoa module and was causing issues. 

Now, users can run parsnp w/out pyspoa by using the `--no-partition` flag.  